### PR TITLE
step4: 동일한 특강에 대해 신청 성공하지 못하도록 개선

### DIFF
--- a/src/test/java/com/hhplus/lecture/ConcurrentTest.java
+++ b/src/test/java/com/hhplus/lecture/ConcurrentTest.java
@@ -80,8 +80,8 @@ public class ConcurrentTest {
         List<Future<Void>> futures = new ArrayList<>();
 
 
-        for (int i = 0; i < 30; i++) {
-            Long currentUserId = ((userId + i) % 10 + 1);  // 같은 사용자가 여러번 신청
+        for (int i = 0; i < 5; i++) {
+            Long currentUserId = userId;  // 같은 사용자가 여러번 신청
 
             Callable<Void> task = () -> {
                 try {
@@ -108,6 +108,9 @@ public class ConcurrentTest {
         Enrollments enrollments = enrollmentService.getEnrollmentsBySchedule(scheduleId);
 
         // 같은 사용자는 한번씩만 신청 가능해야 함.
+        assertThat(enrollments.size()).isEqualTo(1);
         assertThat(enrollments.getEnrollmentList().stream().map(enrollment -> enrollment.user().id())).doesNotHaveDuplicates();
     }
+
+
 }

--- a/src/test/java/com/hhplus/lecture/ConcurrentTest.java
+++ b/src/test/java/com/hhplus/lecture/ConcurrentTest.java
@@ -66,4 +66,48 @@ public class ConcurrentTest {
         // 30개만 있어야 함.
         assertThat(enrollments.size()).isEqualTo(30);
     }
+
+
+    @Description("동일한 사용자가 동일한 특강에 대해 한번씩만 신청 가능해야 한다.")
+    @Test
+    @Transactional
+    void testConcurrentEnrollmentOnlyOnce() throws InterruptedException, ExecutionException {
+        Long scheduleId = 1L;
+        Long userId = 1L;
+
+        // given
+        ExecutorService executorService = Executors.newFixedThreadPool(30);
+        List<Future<Void>> futures = new ArrayList<>();
+
+
+        for (int i = 0; i < 30; i++) {
+            Long currentUserId = ((userId + i) % 10 + 1);  // 같은 사용자가 여러번 신청
+
+            Callable<Void> task = () -> {
+                try {
+                    enrollmentService.enrollLecture(scheduleId, currentUserId);
+                } catch (Exception e) {
+                    System.out.println("신청 1번 초과하여 exception 발생");
+//                    e.printStackTrace();
+                }
+
+                return null;
+            };
+            futures.add(executorService.submit(task));  // 스레드 실행
+        }
+
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        // then
+        Enrollments enrollments = enrollmentService.getEnrollmentsBySchedule(scheduleId);
+
+        // 같은 사용자는 한번씩만 신청 가능해야 함.
+        assertThat(enrollments.getEnrollmentList().stream().map(enrollment -> enrollment.user().id())).doesNotHaveDuplicates();
+    }
 }


### PR DESCRIPTION
동일 유저가 동일 강의는 최대 1번만 신청하도록 제한

- 테스트코드 추가
- 코드 변경사항 없음 (step3에서 처리함)
commit:  a8e4e93412c4828c7890f97c4f11e47c4d8c6fcd


**이상한점**
``` java
        // REVIEW - 조회시점에 DB lock 걸려있음 (1)
        if (Enrollments.isLectureFull(getEnrollmentsBySchedule(scheduleId))) {
            throw new EnrollmentException(ErrorCode.ENROLMENT_LIMIT_EXCEEDED, null, scheduleId, userId);
        }

        // 강의 등록 - 등록시점에 DB lock 걸려있음 (2)
        Enrollment enrollment = new Enrollment(null, schedule, user, null);
        return enrollmentRepository.insert(enrollment);
```

(1)과 (2)이 각각 락이 걸려있는거라, 각각에 대해서는 동시에 수정할 수 없음이 보장되지만 1-2 간에는 보장이 안 되는 것 같습니다.